### PR TITLE
Added multi-walled nanotube generation to chiraltube

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Input files should contain the unit cell of a specific 2D material in special .x
 
 Use option `-h` / `-help` for more help.
 
-###Now supports Multi-Walled Nanotube generation!
+### Now supports Multi-Walled Nanotube generation!
 If you use the option `-mw` you Will be prompted for the number of layers to build and then the chiral índices.
 
 Afterwards you Will be prompted to select a layer-scaling option these are explained here in more detail:

--- a/README.md
+++ b/README.md
@@ -11,3 +11,14 @@ Usage: `python3 ~/chiraltube.py <input file> [<output file>] [<options>]`
 Input files should contain the unit cell of a specific 2D material in special .xyz format or in Quantum Espresso-style .in input files. Several examples of usable unit cells can be found in `~/chiraltube/UnitCellExamples`.
 
 Use option `-h` / `-help` for more help.
+
+###Now supports Multi-Walled Nanotube generation!
+If you use the option `-mw` you Will be prompted for the number of layers to build and then the chiral índices.
+
+Afterwards you Will be prompted to select a layer-scaling option these are explained here in more detail:
+
+* Option 1: Doesn't transform any layer, returns the full MW NT as it was first created. (Recommended if all layers have the same chirality, and therefore have the same height, e.g. both are zigzag NTs)
+* Option 2: Leaves biggest layer unchanged, all the other layers are repeated along the z-axis to surpass the biggest layer. Then they are trimmed so that they are all the same height. (Recommended if you don't care about periodicity of the full NT)
+* Option 3: Leaves biggest layer unchanged, all other layers are scaled up along the z-axis to match the height of the biggest one. (Recommended if all NT heights are very close to each other)
+* Option 4: Leaves biggest layer unchanged. Combination of option 2 and 3. First repeats the smaller layers along the z-axis to get as close as possible to the biggest height, then scales up or down to match the remaining difference. (Recommended, although it might scale too much in certain cases, losing physical plausibility)
+* Option 5: Only works with two layers for now. Looks for a combination of numbers that, when repeating each layer by its corresponding number, makes both layers get close enough for scaling to be practical. (Recommended in most cases, preserves periodicity while staying close to the original stucture. Might not find a supercell, which makes it default to option 4)

--- a/chiraltube.py
+++ b/chiraltube.py
@@ -1683,7 +1683,7 @@ if __name__== "__main__":
             if word=="-multiwalled":
                 mw=False
             else:
-                mw=int(word.strip().replace("-mw",""))
+                mw=int(word.strip().replace("-multiwalled",""))
     if mw==None:    
         main()
     else:


### PR DESCRIPTION
Added the option `-mw` / `-multiwalled` that starts the process of building multi-walled nanotubes. Also added five options for height scaling the resulting layers to match the heights. Description of these options are available in the README file, on the docstring of the new `adjust_layers()` function, and briefly explained when running the program.